### PR TITLE
Make class generic

### DIFF
--- a/src/Java_SE_7/Collection.java
+++ b/src/Java_SE_7/Collection.java
@@ -5,6 +5,6 @@ package Java_SE_7;
  * @param <E> Generic variable for this interface
  * @code This interface adds all methods associated with Collection for Java SE 7.
  */
-public interface Collection
+public interface Collection<E>
 {
 }


### PR DESCRIPTION
Make the class generic by attaching the "<E>" annotation to the end of the class declaration.